### PR TITLE
scrollspy() should be scrollSpy()

### DIFF
--- a/site/_templates/head.mako
+++ b/site/_templates/head.mako
@@ -15,7 +15,7 @@
 <script type="text/javascript">
 
     (function($){
-        $('#topbar').scrollspy();
+        $('#topbar').scrollSpy();
     })(jQuery);
 
   var _gaq = _gaq || [];


### PR DESCRIPTION
Could be nothing. Could be something. I'd rather be _right_ than unsure if I'm wrong.
