### PR TITLE
download informations are displayed twice

### DIFF
--- a/site/_templates/sections/whatispython.mako
+++ b/site/_templates/sections/whatispython.mako
@@ -34,38 +34,3 @@ existing Python 2.x code.</p>
 <p>Cribbed from <a href="http://wiki.python.org/moin/Python2orPython3"
 target="_blank">Python2orPython3</a> on the Python wiki.</p>
 
-<h2 id="download-information" class="caps"><span>Download Information</span></h2>
-<p>The most current version of Python 3 is 3.2.2 - here's a list of 
-new things:
-
-<ul>
-    <li>numerous improvements to the unittest module</li>
-    <li>PEP 3147, support for .pyc repository directories</li>
-    <li>PEP 3149, support for version tagged dynamic libraries</li>
-    <li>PEP 3148, a new futures library for concurrent programming</li>
-    <li>PEP 384, a stable ABI for extension modules</li>
-    <li>PEP 391, dictionary-based logging configuration</li>
-    <li>an overhauled GIL implementation that reduces contention</li>
-    <li>an extended email package that handles bytes messages</li>
-    <li>a much improved ssl module with support for SSL contexts and certificate hostname matching</li>
-    <li>a sysconfig module to access configuration information</li>
-    <li>additions to the shutil module, among them archive file support</li>
-    <li>many enhancements to configparser, among them mapping protocol support</li>
-    <li>improvements to pdb, the Python debugger</li>
-    <li>countless fixes regarding bytes/string issues; among them full support for a bytes environment (filenames, environment variables)</li>
-    <li>many consistency and behavior fixes for numeric operations</li>
-</ul>
-</p>
-
-<p>You can see details on what's changed by looking at the "<a
-href="http://docs.python.org/dev/whatsnew/3.2.html">What's New in 3.2</a>"
-document as well as "<a
-href="http://docs.python.org/release/3.0.1/whatsnew/3.0.html">What's New in
-3.0</a>", and the <a
-href="http://hg.python.org/cpython/file/v3.2.2/Misc/NEWS">change log</a>.
-Builds are available for all major platforms, and OS X users can use <a
-href="http://mxcl.github.com/homebrew/">homebrew</a> via
-<b>"brew install python3"</b></p>
-
-<p><a class="btn primary" href="http://python.org/download/releases/3.2.2/">Go Here to
-Download &raquo;</a></p>


### PR DESCRIPTION
The download section was present both in `sections/whatispython.mako` and in `sections/download.mako`, this pull request removes the one in `sections/whatispython.mako`.
