### PR TITLE
Updated latest Python to 3.3.5

### DIFF
--- a/site/_config.py
+++ b/site/_config.py
@@ -25,7 +25,7 @@ site.file_ignore_patterns = [
 site.template_vars = {
     # The full version number of the latest stable version, e.g. 3.3.0
     # or 3.4.2.
-    'python_stable_exact': '3.3.3',
+    'python_stable_exact': '3.3.5',
 
     # Version number of latest stable version, leaving off the minor number
     # e.g. 3.3 or 3.4.


### PR DESCRIPTION
It was 3.3.3 which is pointing users to old code.

Hopefully next weekend it should be updated to 3.4.0
