### PR TITLE
Updated latest Python to 3.4.0

### DIFF
--- a/site/_config.py
+++ b/site/_config.py
@@ -23,12 +23,12 @@ site.file_ignore_patterns = [
         ]
 
 site.template_vars = {
-    # The full version number of the latest stable version, e.g. 3.3.0
-    # or 3.4.2.
-    'python_stable_exact': '3.3.5',
+    # The full version number of the latest stable version, e.g. 3.4.0
+    # or 3.5.2.
+    'python_stable_exact': '3.4.0',
 
     # Version number of latest stable version, leaving off the minor number
-    # e.g. 3.3 or 3.4.
-    'python_stable_major': '3.3',
+    # e.g. 3.4 or 3.5.
+    'python_stable_major': '3.4',
 
 }


### PR DESCRIPTION
Updated python_stable_exact and python_stable_major for the Python 3.4.0 release.
