### PR TITLE
Update for Python 3.5

### DIFF
--- a/site/_config.py
+++ b/site/_config.py
@@ -25,10 +25,19 @@ site.file_ignore_patterns = [
 site.template_vars = {
     # The full version number of the latest stable version, e.g. 3.4.0
     # or 3.5.2.
-    'python_stable_exact': '3.4.0',
+    'python_stable_exact': '3.5.1',
 
     # Version number of latest stable version, leaving off the minor number
     # e.g. 3.4 or 3.5.
-    'python_stable_major': '3.4',
+    'python_stable_major': '3.5',
+
+    # Month, year of 3.5 release
+    'python_stable_date': 'December 2015',
+
+    # The full version number of latest 2.7 release
+    'python27_exact': '2.7.11',
+
+    # Month, year of most recent 2.7 release
+    'python27_date': 'December 2015',
 
 }

--- a/site/_config.py
+++ b/site/_config.py
@@ -25,19 +25,19 @@ site.file_ignore_patterns = [
 site.template_vars = {
     # The full version number of the latest stable version, e.g. 3.4.0
     # or 3.5.2.
-    'python_stable_exact': '3.5.1',
+    'python_stable_exact': '3.5.2',
 
     # Version number of latest stable version, leaving off the minor number
     # e.g. 3.4 or 3.5.
     'python_stable_major': '3.5',
 
     # Month, year of 3.5 release
-    'python_stable_date': 'December 2015',
+    'python_stable_date': 'June 2016',
 
     # The full version number of latest 2.7 release
-    'python27_exact': '2.7.11',
+    'python27_exact': '2.7.12',
 
     # Month, year of most recent 2.7 release
-    'python27_date': 'December 2015',
+    'python27_date': 'June 2016',
 
 }

--- a/site/_templates/sections/download.mako
+++ b/site/_templates/sections/download.mako
@@ -1,25 +1,7 @@
 <h2 id="download-information" class="caps"><span>Download Information</span></h2>
-<p>The most current version of Python 3 is ${python_stable_exact} - here's a list of
-new things added:
+<p>The most current version of Python 3 is ${python_stable_exact}.</p>
 
-<ul>
-    <li><code>yield from</code> expression for delegating to a generator (PEP 380)
-    <li>new library modules for LZMA compression, mock objects for unit tests,
-        and  representing IP addresses
-    <li>the decimal type has been re-implemented in C, making it much faster
-    <li>PEP 393, Flexible String Representation, which reduces memory usage
-        and removes the distinction between narrow and wide builds of Python.
-    <li>PEP 397, a Windows&reg; launcher for *.py files.
-    <li>PEP 405, Python Virtual Environments</li>
-    <li>PEP 3118, new implementation of the memoryview type.</li>
-    <li>PEP 3151, reworked hierarchy of OS and I/O exceptions</li>
-    <li>the <code>import</code> statement is now built atop the importlib module</li>
-    <li>for easier porting to Python 3, the <code>u''</code> syntax is now accepted again</li>
-    <li>security fix: hash randomization is now enabled by default.</li>
-</ul>
-</p>
-
-<p>You can see details on what's changed by looking at the "<a
+<p>You can see details of what's changed by looking at the "<a
 href="http://docs.python.org/dev/whatsnew/${python_stable_major}.html">What's New in ${python_stable_major}</a>"
 document, as well as <a
 href="http://docs.python.org/3/whatsnew/">the earlier What's New articles</a>, and the <a

--- a/site/_templates/sections/whatispython.mako
+++ b/site/_templates/sections/whatispython.mako
@@ -49,9 +49,10 @@ language changes between 2.7 and 3.x, and discusses likely sources of
 incompatibility with existing Python 2.x code.</p>
 
 <p>Later versions of Python 3.x added more features, discussed in a series of
-  "What's New" documents for 
+  "What's New" documents for
 <a href="http://docs.python.org/dev/whatsnew/3.1.html">Python 3.1</a>,
 <a href="http://docs.python.org/dev/whatsnew/3.2.html">Python 3.2</a>,
-<a href="http://docs.python.org/dev/whatsnew/3.3.html">Python 3.3</a>, and
-<a href="http://docs.python.org/dev/whatsnew/3.4.html">Python 3.4</a>.
+<a href="http://docs.python.org/dev/whatsnew/3.3.html">Python 3.3</a>,
+<a href="http://docs.python.org/dev/whatsnew/3.4.html">Python 3.4</a>, and
+<a href="http://docs.python.org/dev/whatsnew/3.5.html">Python 3.5</a>.
 </p>

--- a/site/_templates/sections/whatispython.mako
+++ b/site/_templates/sections/whatispython.mako
@@ -5,13 +5,13 @@
 <p>Although most Python code is currently written for Python
 2.x, Python 3.x is the present and future of the language.</p>
 
-<p>Python 2.7.6 was released in November 2013.
+<p>Python ${python27_exact} was released in ${python27_date}.
 The 2.x branch will have no further major releases,
 though the 2.7 end-of-life release will have an extended period of bug
 and security fixes.
 
 <p>Python 3.x continues to be actively developed.  The most recent
-release is Python ${python_stable_major}, released in March 2014.</p>
+release is Python ${python_stable_exact}, released in ${python_stable_date}.</p>
 
 
 <h3>Detailed discussion</h3>


### PR DESCRIPTION
Updates the site for Python 3.5, and makes it easier to update the release date for Python 2.7.
